### PR TITLE
Parse status codes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='xdrparser',
-    version='1.1.0',
+    version='1.2.0',
     author="Ron Serruya",
     author_email="ron.serruya@kik.com",
     description="Xdr parser for stellar history files",
@@ -21,7 +21,7 @@ setup(
     ),
     install_requires=[
         'Click==6.7',
-        'stellar-base==0.1.8.1'
+        'kin-base==1.0.2'
     ],
     entry_points='''
         [console_scripts]

--- a/xdrparser/cli.py
+++ b/xdrparser/cli.py
@@ -1,4 +1,4 @@
-"""Command line tool to parse Stellar's xdr history files."""
+"""Command line tool to parse Kin's xdr history files."""
 import json
 import re
 


### PR DESCRIPTION
Changes:
1. Updated to version 1.2 (accidentally released 1.1.1 before without uploading to git) :sweat_smile:
2. Parsing startingBalance (that was the 1.1.1 change)
3. Now parsing status codes as well

resulting output example

```
"transactionHash": "4e4f6c50e87757e863ada05a29ccb25cc5d0f5f9ea93104834b128df660bf1e8",
          "result": {
            "feeCharged": 200,
            "result": {
              "code": "txFAILED",
              "results": [
                {
                  "code": "opINNER",
                  "tr": {
                    "type": 0,
                    "createAccountResult": {
                      "code": "CREATE_ACCOUNT_ALREADY_EXIST"
                    }
                  }
                },
```